### PR TITLE
[Feature] LWWRegister (Last-Write-Wins) 구현

### DIFF
--- a/src/main/java/moanote/backend/domain/LWWRegister.java
+++ b/src/main/java/moanote/backend/domain/LWWRegister.java
@@ -1,0 +1,64 @@
+package moanote.backend.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import java.util.Optional;
+
+/**
+ * LWWRegister 은 Last-Write-Wins Register 의 약자로, 가장 최근에 업데이트된 값을 가지는 레지스터를 의미한다.
+ * State-based CRDT 중 하나이다.
+ * @param <T> 동기화 할 데이터 타입. Record 이어야 한다.
+ */
+@Getter
+public class LWWRegister<T extends Record> {
+
+  /**
+   * stateId 는 timeStamp 가 같을 때, 두 레지스터의 값을 비교할 때 사용된다.
+   * Tie-breaker 로 사용된다.
+   */
+  private String stateId;
+
+  /**
+   * 논리 시계로, 레지스터의 업데이트 시간을 나타낸다.
+   */
+  private int timeStamp;
+
+  @Getter(AccessLevel.NONE)
+  private T value;
+
+  LWWRegister(String stateId, int timeStamp, T value) {
+    this.stateId = stateId;
+    this.timeStamp = timeStamp;
+    this.value = value;
+  }
+
+  LWWRegister(String stateId) {
+    this.stateId = stateId;
+    this.timeStamp = 0;
+    this.value = null;
+  }
+
+  /**
+   * 다른 레지스터와 병합한다.
+   * @param other 병합할 레지스터
+   * @return 다른 레지스터가 더 최신이면 true, 아니면 false
+   */
+  public boolean merge(LWWRegister<T> other) {
+    String othersStateId = other.getStateId();
+    int othersTimeStamp = other.getTimeStamp();
+    T othersValue = other.getValue().orElse(null);
+
+    if (othersTimeStamp > this.timeStamp || (othersTimeStamp == this.timeStamp
+        && othersStateId.compareTo(this.stateId) > 0)) {
+      this.stateId = othersStateId;
+      this.timeStamp = othersTimeStamp;
+      this.value = othersValue;
+      return true;
+    }
+    return false;
+  }
+
+  public Optional<T> getValue() {
+    return Optional.ofNullable(value);
+  }
+}

--- a/src/test/java/moanote/backend/domain/LWWRegisterTest.java
+++ b/src/test/java/moanote/backend/domain/LWWRegisterTest.java
@@ -1,0 +1,107 @@
+package moanote.backend.domain;
+
+import lombok.Getter;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LWWRegisterTest {
+
+  /**
+   * list의 다음 순열을 구한다.
+   * @param list 다음 순열을 구할 리스트
+   * @return 다음 순열이 있으면 true, 없으면 false
+   * @param <T> 리스트의 타입
+   */
+  <T extends Comparable<T>>
+  boolean nextPermutation(ArrayList<T> list) {
+    int i = list.size() - 1;
+    while (i > 0 && list.get(i - 1).compareTo(list.get(i)) >= 0) {
+      i--;
+    }
+    if (i <= 0) {
+      return false;
+    }
+    int j = list.size() - 1;
+    while (list.get(j).compareTo(list.get(i - 1)) <= 0) {
+      j--;
+    }
+    T temp = list.get(i - 1);
+    list.set(i - 1, list.get(j));
+    list.set(j, temp);
+    j = list.size() - 1;
+    while (i < j) {
+      temp = list.get(i);
+      list.set(i, list.get(j));
+      list.set(j, temp);
+      i++;
+      j--;
+    }
+    return true;
+  }
+  record TextValue(String content) {}
+
+  /**
+   * editCount 번의 수정이 3명의 사용자로부터 발생하는 경우를 테스트한다.
+   * 각 사용자가 수정한 순서대로 수정을 적용하고, 최종적으로 합치는 과정에서
+   * 합치는 순서가 달라도 최종적으로는 같은 값이 나오는지 확인한다.
+   */
+  @Test
+  void testEventualConsistency() {
+    int editCount = 7;
+    String[] userid = {"user0", "user1", "user2"};
+    LinkedList<LWWRegister<TextValue>> lwwRegisterList = new LinkedList<>();
+    ArrayList<Integer> editOrder = new ArrayList<>(editCount);
+    ArrayList<Integer> editByWho = new ArrayList<>(editCount);
+
+    for (int i = 0; i < 10; i++) {
+      editByWho.add(0);
+    }
+
+    while (true) {
+      lwwRegisterList = new LinkedList<>();
+      LWWRegister<TextValue> finalLwwRegister = null;
+
+      int[] editCountByWho = {0, 0, 0};
+      Integer cnt = 0;
+      for (Integer editor : editByWho) {
+        cnt++;
+        editCountByWho[editor]++;
+        lwwRegisterList.add(new LWWRegister<>(userid[editor],
+            editCountByWho[editor], new TextValue(Integer.toString(cnt))));
+      }
+
+      editOrder = new ArrayList<>(editCount);
+      for (int i = 0; i < editCount; i++) {
+        editOrder.add(i);
+      }
+      do {
+        LWWRegister<TextValue> lwwRegisterNow = new LWWRegister<>(userid[0]);
+        for (int i = 0; i < editCount; i++) {
+          lwwRegisterNow.merge(lwwRegisterList.get(editOrder.get(i)));
+        }
+        if (finalLwwRegister == null) {
+          finalLwwRegister = lwwRegisterNow;
+          continue;
+        }
+        assertEquals(finalLwwRegister.getValue().get(), lwwRegisterNow.getValue().get());
+      } while (nextPermutation(editOrder));
+
+      boolean isEnd = true;
+      for (int i = editCount - 1; i >= 0; i--) {
+        if (editByWho.get(i) < 2) {
+          editByWho.set(i, editByWho.get(i) + 1);
+          isEnd = false;
+          break;
+        } else {
+          editByWho.set(i, 0);
+        }
+      }
+      if (isEnd)
+        break;
+    }
+  }
+}


### PR DESCRIPTION
## 요약
이 커밋들은 이슈 #19 에 대한 작업으로, LWWRegister (Last-Write-Wins) 데이터를 구현하고, 해당 클래스에 대한 강한 최종 일관성을 검증하는 유닛 테스트를 추가하였습니다. 

이를 통해 동시 편집 중 서버에서도 동기화된 데이터를 유지할 수 있게 됩니다.


## 기능 설명
- State-based CRDT 중 하나인 LWWRegister 데이터 구조 구현
- 해당 로직에서는 여러 변경 사항이 발생하면, 항상 마지막 수정만 수용됩니다.

## 구현 이유
- 동시 편집 중 서버에서도 동기화된 데이터를 가지기 위해 필요

## 추가 정보
- [CRDT에 대한 인터랙티브 입문](https://junghan92.medium.com/%EB%B2%88%EC%97%AD-crdt%EC%97%90-%EB%8C%80%ED%95%9C-%EC%9D%B8%ED%84%B0%EB%9E%99%ED%8B%B0%EB%B8%8C-%EC%9E%85%EB%AC%B8-818403128cca)

## 커밋 요약
**feat(Collaborative Editing): 다양한 데이터 타입에 대해 State-based CRDT 로직으로 동기화가 가능한 LWWRegister 클래스 구현 (ast-Write-Wins) #19**

- 상태 기반 CRDT 설계를 위한 LWWRegister 클래스 추가.
- 다양한 데이터 타입에 대해 동기화할 수 있음

**test(Collaborative Editing): LWWRegister 클래스에 대해 강한 최종 일관성을 검증하는 유닛 테스트 작성 #19**

- 강한 최종 일관성을 (Strong Eventual Consistency) 만족하는 지에 대한 테스트 시나리오를 구현하였습니다.
- 임의의 문서 수정에 대해 적용 순서와 관계없이 같은 값이 나오는 지를 확인
