### PR TITLE
Feature/collaborative editing controller

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,10 @@
 			<groupId>org.apache.httpcomponents.client5</groupId>
 			<artifactId>httpclient5</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-websocket</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/moanote/backend/config/WebSocketConfig.java
+++ b/src/main/java/moanote/backend/config/WebSocketConfig.java
@@ -1,0 +1,24 @@
+package moanote.backend.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+  @Override
+  public void configureMessageBroker(MessageBrokerRegistry config) {
+    config.enableSimpleBroker("/topic");
+    config.setApplicationDestinationPrefixes("/app");
+  }
+
+  @Override
+  public void registerStompEndpoints(StompEndpointRegistry registry) {
+    registry.addEndpoint("/docs").setAllowedOrigins("*");
+  }
+
+}

--- a/src/main/java/moanote/backend/controller/CollaborativeEditingController.java
+++ b/src/main/java/moanote/backend/controller/CollaborativeEditingController.java
@@ -1,0 +1,37 @@
+package moanote.backend.controller;
+
+import moanote.backend.domain.LWWNoteContent;
+import moanote.backend.dto.LWWStateDTO;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.stereotype.Controller;
+
+@Controller
+public class CollaborativeEditingController {
+
+  /**
+   * <pre>
+   * body : LWWStateDTO<LWWNoteContent>
+   * {
+   *  "stateId":String
+   *  "timeStamp":Number,
+   *  "value":{
+   *      "content":String
+   *    }
+   *  }
+   *  </pre>
+   *
+   * @param editedContent 문서 동기화를 위해 주고 받는 수정 사항
+   */
+  @MessageMapping("/docs/edit/{docId}")
+  @SendTo("/topic/docs/{docId}")
+  public LWWStateDTO<LWWNoteContent> editingDocs(LWWStateDTO<LWWNoteContent> editedContent,
+      @DestinationVariable("docId") String docId) {
+    System.out.println("Edited content received");
+    // TODO@ (ACLService) ACL check here
+    // TODO@ (CollaborativeService) 서버의 문서를 동기화하는 로직을 추가해야 함
+    return editedContent;
+  }
+
+}

--- a/src/main/java/moanote/backend/domain/LWWNoteContent.java
+++ b/src/main/java/moanote/backend/domain/LWWNoteContent.java
@@ -1,0 +1,10 @@
+package moanote.backend.domain;
+
+/**
+ * <pre>
+ * LWWRegister 을 통해 동기화되는 Value 데이터입니다.
+ * 해당 레코드의 동기화 대상은 Note 의 content 입니다.
+ * </pre>
+ * @param content
+ */
+public record LWWNoteContent(String content) {}

--- a/src/main/java/moanote/backend/dto/LWWStateDTO.java
+++ b/src/main/java/moanote/backend/dto/LWWStateDTO.java
@@ -1,0 +1,17 @@
+package moanote.backend.dto;
+
+
+/**
+ * 문서 동기화를 위해 주고 받는 수정 사항 DTO
+ * @param stateId LWW state ID
+ * @param timeStamp LWW state timestamp
+ * @param value LWW state value
+ * @param <T> LWW state value type
+ */
+public record LWWStateDTO<T extends Record>(String stateId, int timeStamp, T value) {
+    public LWWStateDTO {
+        if (stateId == null || stateId.isEmpty()) {
+            throw new IllegalArgumentException("State ID cannot be null or empty");
+        }
+    }
+}


### PR DESCRIPTION
## 이슈 요약
이슈 #20은 클라이언트의 수정 사항을 받아서 같은 문서를 편집하는 다른 클라이언트에게 전달할 수 있도록 하는 WebSocket 컨트롤러인 `CollaborativeEditingController`를 구현하는 것입니다. 이 컨트롤러는 CRDT 로직이 변경되더라도 수정 사항을 중계할 수 있도록 설계되었습니다. STOMP 프로토콜의 Publish/Subscribe 구조를 활용하여 클라이언트 간의 실시간 수정 사항 동기화를 지원합니다.

## 관련 이슈
- #20

## 커밋 요약
 **build(dependencies): STOMP, WebSocket 지원 추가. Built-in Simple Message broker 설정. 모든 Origin을 허용하는 CORS 설정 #20**
  - `pom.xml`에 `spring-boot-starter-websocket` 의존성 추가
  - WebSocketConfig.java `@Configuration` Bean을 통한 WebSocket 기능 설정
  - In-memory에서 동작하는 built-in simple message broker를 Message Broker로 설정 (이후에 다른 외부 브로커를 고려할 수 있습니다)
  - 모든 Origin에 대해 CORS를 허용합니다.
- **변경 파일:**
  - `pom.xml`: spring-boot-starter-websocket 의존성 추가
  - `src/main/java/moanote/backend/config/WebSocketConfig.java`: WebSocket 설정 클래스 추가
- **커밋 URL:** [7a6e796bd6f9d1d6b98fc3be67c5e36a5782a757](https://github.com/CBNU-MoaNote-CapstonDesign/backend/commit/7a6e796bd6f9d1d6b98fc3be67c5e36a5782a757)

**feat(CollaborativeEditing): `CollaborativeEditingController` 추가. 수정 사항 중계를 위한 pub/sub 엔드포인트 추가. 관련 DTO 추가. #20**
  - `/docs/edit/{docId}` 엔드포인트에 대한 WebSocket 메시지 매핑 추가
  - 클라이언트가 발신한 수정 사항을 `/topic/docs/{docId}`으로 전송
  - 관련 DTO `LWWStateDTO` 및 관련 타입 `LWWNoteContent` 추가
  - TODO 추가: ACL 검증 및 서버 문서 동기화 로직 구현 필요
- **변경 파일:**
  - `CollaborativeEditingController.java`: WebSocket 컨트롤러 클래스 추가
  - `LWWStateDTO.java`, `LWWNoteContent.java`: 관련 DTO 클래스 추가
- **커밋 URL:** [910b8471e2278959b736ebde5ecb8d8601204709](https://github.com/CBNU-MoaNote-CapstonDesign/backend/commit/910b8471e2278959b736ebde5ecb8d8601204709)

## 추가 정보
- 이 PR은 CollaborativeEditing 기능을 위한 기본적인 WebSocket 및 STOMP 구성과 관련된 기능을 추가합니다.
- 클라이언트 간 실시간 수정 사항 동기화를 위해 pub/sub 구조를 도입했습니다.