### PR TITLE
[Feature] 동시 편집 문서별 세션 상태 관리

### DIFF
--- a/src/main/java/moanote/backend/domain/CollaborationSession.java
+++ b/src/main/java/moanote/backend/domain/CollaborationSession.java
@@ -1,0 +1,72 @@
+package moanote.backend.domain;
+
+import moanote.backend.entity.Note;
+import moanote.backend.entity.User;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 동일한 노트를 동시 편집하는 사용자 목록과 편집 사항을 관리하는 클래스입니다.
+ */
+public class CollaborationSession {
+
+  /**
+   * 동시 편집을 위한 LWWRegister 입니다. Content 를 관리합니다.
+   *
+   * @see LWWRegister
+   */
+  final private LWWRegister<LWWNoteContent> lwwRegister;
+
+  /**
+   * 동시 편집에 참여하는 사용자 목록입니다. ConcurrentHashMap 으로 Thread-safe 하게 관리합니다.
+   */
+  final private Map<Long, User> participants;
+
+  public CollaborationSession(Note note) {
+    this.lwwRegister = new LWWRegister<>("init", 0, new LWWNoteContent(note.getContent()));
+    participants = new ConcurrentHashMap<>();
+  }
+
+  /**
+   * 수정에 참여하는 사용자를 추가하는 Thread-safe 메소드입니다.
+   *
+   * @param user 수정에 참여한 사용자
+   */
+  public void addParticipant(User user) {
+    participants.put(user.getId(), user);
+  }
+
+  /**
+   * 동시 편집에 더 이상 참여하지 않는 사용자를 제거하는 Thread-safe 메소드입니다.
+   *
+   * @param user 수정자 목록에서 제거할 사용자
+   */
+  public void removeParticipant(User user) {
+    participants.remove(user.getId());
+  }
+
+  /**
+   * 수정에 참여하는 사용자 목록을 반환합니다. item 을 추가 혹은 삭제할 수 없도록 `unmodifiableMap` 으로 감싸서 반환합니다.
+   *
+   * @return 수정에 참여하는 사용자 목록
+   */
+  public Map<Long, User> getParticipants() {
+    return Collections.unmodifiableMap(participants);
+  }
+
+  /**
+   * 수정에 참여 중인 사용자 수를 반환합니다.
+   * @return 수정에 참여 중인 사용자 수
+   */
+  public Integer getParticipantsCount() {
+    return participants.size();
+  }
+
+  /**
+   * 편집 사항을 적용하는 메소드입니다. LWWRegister 를 사용하여 편집 사항을 적용합니다.
+   */
+  public void applyEdit(LWWRegister<LWWNoteContent> others) {
+    lwwRegister.merge(others);
+  }
+}

--- a/src/main/java/moanote/backend/dto/CreateCollaborationSessionDTO.java
+++ b/src/main/java/moanote/backend/dto/CreateCollaborationSessionDTO.java
@@ -1,0 +1,9 @@
+package moanote.backend.dto;
+
+public record CreateCollaborationSessionDTO(
+    String sessionId,
+    Long noteId,
+    String sessionCreateUserId
+) {
+
+}

--- a/src/main/java/moanote/backend/service/CollaborativeEditingService.java
+++ b/src/main/java/moanote/backend/service/CollaborativeEditingService.java
@@ -1,0 +1,64 @@
+package moanote.backend.service;
+
+import moanote.backend.domain.CollaborationSession;
+import moanote.backend.dto.CreateCollaborationSessionDTO;
+import moanote.backend.entity.Note;
+import moanote.backend.entity.User;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Collaborative editing sessions 을 관리하는 서비스 클래스
+ * TODO@ 실제로 DB 의 Note 내용을 변경하는 로직을 구현해야 함
+ * TODO@ 세션이 종료되면 DB 에서 세션을 삭제하는 로직을 구현해야 함
+ */
+@Service
+public class CollaborativeEditingService {
+
+  final private Map<String, CollaborationSession> collaborationSessions;
+
+  final private NoteService noteService;
+
+  final private UserService userService;
+
+  @Autowired
+  public CollaborativeEditingService(NoteService noteService, UserService userService) {
+    this.noteService = noteService;
+    this.userService = userService;
+    this.collaborationSessions = new ConcurrentHashMap<>();
+  }
+
+  public List<User> getUsersInSession(String sessionId) {
+    CollaborationSession session = collaborationSessions.get(sessionId);
+    if (session != null) {
+      return session.getParticipants().values().stream().toList();
+    }
+    throw new IllegalArgumentException("Session not found");
+  }
+
+  /**
+   * 협업 세션 생성의 entry point. 세션 ID 는 아마도 STOMP 에서 생성된 UUID 를 사용하게 될 것 같습니다.
+   * @param request 세션 생성 요청 DTO
+   */
+  public void createSession(CreateCollaborationSessionDTO request) {
+    Note note = noteService.getNoteById(request.noteId());
+    // TODO@ User 와 UserRepository 는 다른 기능 추가 중 변경 될 예정
+    User participant = userService.findByUsername(request.sessionCreateUserId());
+    doCreateSession(note, participant, request.sessionId());
+  }
+
+  /**
+   * 세션을 실제로 생성하는 메소드. 기능과 DB 및 Service 와의 의존성을 분리하기 위해 만들어졌습니다.
+   * @param note 동시 수정 대상 노트
+   * @param participant 동시 수정 세션 참여자
+   * @param sessionId 세션 ID
+   */
+  public void doCreateSession(Note note, User participant, String sessionId) {
+    CollaborationSession session = new CollaborationSession(note);
+    session.addParticipant(participant);
+    collaborationSessions.put(sessionId, session);
+  }
+}


### PR DESCRIPTION
## 관련 이슈

- Closes #23
- Closes #26
- Closes #27

## 관련 커밋

- 3d45f400e08a11c2249cd3d7cad5384d501bcd8e
- 9cfa9511fe9541a67322ee4bce339e97be5d6e08
- 3c747eabd7ef568d9a1b97f526cc843b03dd2f80

## 설명

#### CollaborativeEditingService 구현 (#23)
- 각 문서에 대해 `LWWRegister`를 관리하기 위한 `CollaborativeEditingService`를 구현하였습니다.
- 동시 편집을 위해 문서의 채널 (`/topic/docs/{docId}`)에 사용자를 구독시킵니다.

#### Thread-Safe LWWRegister::merge 메서드 (#26)
- `LWWRegister::merge` 메서드를 thread-safe 하도록 수정하였습니다.
- 동시 편집 중 `LWWRegister`에 대한 작업을 안전하게 처리하기 위해 `synchronized (this)` 블록을 사용하였습니다.

#### CollaborationSession 클래스 구현 (#27)
- 여러 사용자가 동일한 문서를 동시에 편집할 수 있도록 `CollaborationSession` 클래스를 구현하였습니다.
- `ConcurrentHashMap`을 사용하여 사용자를 관리하고 thread-safe한 작업을 보장합니다.
- 사용자를 추가/제거하고 `LWWRegister::merge` 메서드를 사용하여 편집 사항을 적용하는 메서드를 제공하였습니다.
