### PR TITLE
로그인 및 유저정보에 대한 API route 추가 및 로그인 완료시 프론트엔드로 리다이렉팅

### DIFF
--- a/src/main/java/moanote/backend/config/SecurityConfig.java
+++ b/src/main/java/moanote/backend/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package moanote.backend.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -18,6 +19,9 @@ public class SecurityConfig {
 
   private final CustomUserDetailsService userDetailsService;
 
+  @Value("${frontend.url}")
+  private String frontendUrl;
+
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
     return http
@@ -31,7 +35,7 @@ public class SecurityConfig {
         )
         .formLogin(form -> form
             .loginPage("/login") // 커스텀 로그인 페이지
-            .defaultSuccessUrl("/home", true)
+            .defaultSuccessUrl(frontendUrl, true)
             .permitAll()
         )
         .logout(logout -> logout

--- a/src/main/java/moanote/backend/controller/UserController.java
+++ b/src/main/java/moanote/backend/controller/UserController.java
@@ -1,10 +1,18 @@
 package moanote.backend.controller;
 
+import moanote.backend.dto.UserDataDTO;
 import moanote.backend.entity.UserData;
+import moanote.backend.repository.NoteRepository;
+import moanote.backend.repository.UserDataRepository;
+import moanote.backend.security.CustomUserDetails;
 import moanote.backend.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import java.util.Map;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/users")
@@ -18,4 +26,56 @@ public class UserController {
     // TODO@ 적절한 DTO 객체를 받도록 변경
     return userService.createUser(userData.get("username"), userData.get("password"));
   }
+
+  private boolean isLoggedIn(Authentication authentication) {
+    return authentication != null && authentication.getPrincipal() instanceof CustomUserDetails;
+  }
+
+  /**
+   * GET /api/users/me
+   * 내 정보를 받아오는 API 입니다.
+   *
+   * @param authentication 유저의 http-only 토큰이 Spring Security에 의해 자동 주입됨
+   * @return 로그인 되어있으면 유저의 UserDataDTO, 미로그인시 UNAUTHORIZED
+   */
+  @GetMapping("/me")
+  public ResponseEntity<?> getCurrentUser(Authentication authentication) {
+    if (!isLoggedIn(authentication))
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("");
+
+    // authentication의 getPrincipal()에서 필요한 정보만 뽑아서 UserDataDTO로 저장
+    CustomUserDetails user = (CustomUserDetails) authentication.getPrincipal();
+    UserDataDTO data = new UserDataDTO(user.getId(), user.getUsername());
+    System.out.println(user.getId());
+
+    return ResponseEntity.ok(data);
+  }
+
+  @Autowired
+  private UserDataRepository userDataRepository;
+
+  /**
+   * GET /api/users/{userId}
+   * 해당하는 id의 유저 정보를 찾는 API 입니다.
+   *
+   * @param authentication 유저의 http-only 토큰이 Spring Security에 의해 자동 주입됨
+   * @param userId 정보를 찾고자 하는 유저의 ID
+   * @return 유저가 있으면 UserDataDTO, 없으면 NOT_FOUND, 미로그인시 UNAUTHORIZED
+   */
+  @GetMapping("/{userId}")
+  public ResponseEntity<?> getUser(Authentication authentication, @PathVariable UUID userId) {
+    if (!isLoggedIn(authentication))
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("");
+
+    UserData user = userDataRepository.findById(userId).orElse(null);
+
+    if (user == null) {
+      return ResponseEntity.status(HttpStatus.NOT_FOUND).body("User not found");
+    }
+
+    UserDataDTO data = new UserDataDTO(user.getId(), user.getUsername());
+
+    return ResponseEntity.ok(data);
+  }
+
 }

--- a/src/main/java/moanote/backend/dto/UserDataDTO.java
+++ b/src/main/java/moanote/backend/dto/UserDataDTO.java
@@ -1,0 +1,13 @@
+package moanote.backend.dto;
+
+/**
+ * <pre>
+ *   UserDataDTO
+ *   유저 정보 DTO
+ * </pre>
+ * @param id
+ * @param name
+ */
+public record UserDataDTO(java.util.UUID id, String name) {
+
+}

--- a/src/main/java/moanote/backend/security/CustomUserDetails.java
+++ b/src/main/java/moanote/backend/security/CustomUserDetails.java
@@ -72,4 +72,8 @@ public class CustomUserDetails implements UserDetails {
   public boolean isEnabled() {
     return true;
   }
+
+  public UUID getId() {
+    return user.getId();
+  }
 }

--- a/src/main/resources/application.properties.example
+++ b/src/main/resources/application.properties.example
@@ -1,6 +1,9 @@
 spring.application.name=backend
 server.port=스프링_서버_포트_번호_입력
 
+# FE url
+frontend.url=http://localhost:3000
+
 # 오픈 AI API 정보 설정
 openai.api.url=오픈_AI_API_요청_주소_입력
 openai.api.key=오픈_AI_API_키값_입력


### PR DESCRIPTION
1. 로그인 및 유저 정보에 대한 API route 추가 
* UserDataDTO 추가 -> FE에 UserData를 보내주는데 필요
* CustomUserDetails에 getId() 추가 -> UUID를 FE에 보내주기 위해 필요
* /api/user/me : 현재 로그인 된 사용자 정보를 받아올 수 있습니다. FE에서 로그인 되었는지 여부를 판단하는데도 사용 가능합니다.
* /api/user/{userId}" : id를 이용해 유저 정보를 받아올 수 있습니다.

2. /login에서 로그인 하면 프론트엔드로 리다이렉팅 할 수 있도록 했습니다. application.properties에서 frontend.url을 설정하셔야 합니다.