### PR TITLE
[Feature] 클라이언트가 유저가 열람할 권한이 있는 모든 문서를 조회하는 시나리오 지원

### DIFF
--- a/src/main/java/moanote/backend/controller/NoteController.java
+++ b/src/main/java/moanote/backend/controller/NoteController.java
@@ -21,6 +21,11 @@ public class NoteController {
   }
 
   @GetMapping("/user/{userId}")
+  public List<Note> getNotesByUser(@PathVariable UUID userId) {
+    return noteService.getNotesByUserId(userId);
+  }
+
+  @GetMapping("/user/{userId}/owner")
   public List<Note> getNotesByOwner(@PathVariable UUID userId) {
     return noteService.getNotesByOwnerUserId(userId);
   }

--- a/src/main/java/moanote/backend/controller/TestController.java
+++ b/src/main/java/moanote/backend/controller/TestController.java
@@ -2,6 +2,7 @@ package moanote.backend.controller;
 
 import moanote.backend.config.SecurityConfig;
 import moanote.backend.entity.Note;
+import moanote.backend.entity.NoteUserData;
 import moanote.backend.entity.UserData;
 import moanote.backend.repository.NoteUserDataRepository;
 import moanote.backend.service.NoteService;
@@ -45,15 +46,19 @@ public class TestController {
       users.add(userService.createUser("kim", password));
       users.add(userService.createUser("sa", password));
       users.add(userService.createUser("son", password));
+
+
+      for (int i = 0; i < users.size(); i++) {
+        notes.add(noteService.createNote(users.get(i).getId()));
+        noteService.updateNote(notes.get(i).getId(), "노트" + i);
+        for (int j = 0; j < users.size(); j++) {
+          if (i != j) {
+            noteService.grantPermission(notes.get(i).getId(), users.get(j).getId(), NoteUserData.Permission.valueOf("WRITE"));
+          }
+        }
+      }
+
       users.add(userService.createUser("moa-bot-id", password));
-
-      notes.add(noteService.createNote(users.get(0).getId()));
-      notes.add(noteService.createNote(users.get(1).getId()));
-      notes.add(noteService.createNote(users.get(2).getId()));
-
-      noteService.updateNote(notes.get(0).getId(), "노트1");
-      noteService.updateNote(notes.get(1).getId(), "노트2");
-      noteService.updateNote(notes.get(2).getId(), "노트3");
 
       return "<html><body><h1>테스트 데이터 주입 완료</h1></body></html>";
     } catch (Exception e) {

--- a/src/main/java/moanote/backend/repository/NoteRepository.java
+++ b/src/main/java/moanote/backend/repository/NoteRepository.java
@@ -26,6 +26,14 @@ public interface NoteRepository extends JpaRepository<Note, UUID> {
       """)
   List<Note> findNotesByOwner(@Param("owner") UUID ownerUserId);
 
+  @Query(value = """
+      SELECT n
+      FROM Note n
+      JOIN NoteUserData nud ON n.id = nud.note.id
+      WHERE nud.user.id = :user
+      """)
+  List<Note> findNotesByUser(@Param("user") UUID ownerUserId);
+
   Optional<Note> findById(UUID noteId);
 
   default Note createNote() {

--- a/src/main/java/moanote/backend/repository/NoteUserDataRepository.java
+++ b/src/main/java/moanote/backend/repository/NoteUserDataRepository.java
@@ -5,6 +5,7 @@ import moanote.backend.entity.UserData;
 import moanote.backend.entity.NoteUserData;
 import moanote.backend.entity.NoteUserDataId;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface NoteUserDataRepository extends JpaRepository<NoteUserData, NoteUserDataId> {
@@ -19,4 +20,6 @@ public interface NoteUserDataRepository extends JpaRepository<NoteUserData, Note
   }
 
   void deleteAllByNoteId(UUID noteId);
+
+  Optional<NoteUserData> findByNoteAndUser(Note note, UserData user);
 }

--- a/src/main/java/moanote/backend/service/NoteService.java
+++ b/src/main/java/moanote/backend/service/NoteService.java
@@ -115,6 +115,7 @@ public class NoteService {
 
   /**
    * note와 연관된 note_user_data를 모두 삭제한 뒤 note를 삭제합니다.
+   *
    * @param note 지울 note
    * @return 성공시 true, 실패시 false
    */
@@ -131,6 +132,7 @@ public class NoteService {
 
   /**
    * 전체 note 레코드를 지웁니다.
+   *
    * @return 성공시 true, 실패시 false
    */
   public boolean deleteAll() {

--- a/src/main/java/moanote/backend/service/NoteService.java
+++ b/src/main/java/moanote/backend/service/NoteService.java
@@ -104,6 +104,16 @@ public class NoteService {
   }
 
   /**
+   * userId 와 연관된 모든 note 를 가져옵니다.
+   *
+   * @param userId userId
+   * @return userId와 연관된 모든 note
+   */
+  public List<Note> getNotesByUserId(UUID userId) {
+    return noteRepository.findNotesByUser(userId);
+  }
+
+  /**
    * note와 연관된 note_user_data를 모두 삭제한 뒤 note를 삭제합니다.
    * @param note 지울 note
    * @return 성공시 true, 실패시 false

--- a/src/main/java/moanote/backend/service/NoteService.java
+++ b/src/main/java/moanote/backend/service/NoteService.java
@@ -23,6 +23,7 @@ public class NoteService {
 
   private final NoteUserDataRepository noteUserDataRepository;
 
+  @Autowired
   public NoteService(NoteRepository noteRepository, UserDataRepository userDataRepository,
       NoteUserDataRepository noteUserDataRepository) {
     this.noteRepository = noteRepository;


### PR DESCRIPTION
## 수행한 작업
### fix
- `NoteService` 에서 누락된 `@Autowired` 어노테이션 추가 65272aa36a20aed8a7560413c2acf8f00695beb1
### feat
- `NoteService::grantPermission` 를 추가하여 문서에 대한 유저의 권한을 수정할 수 있도록 함 4819d08377c2f6dee69c9397177673783f7e38f7
- 개발용 더미 데이터에 유저의 쓰기 권한 데이터 추가 34f4b485699d8ccf6225fae0a987a01b6fa5a576
- 유저가 읽을 수 있는 모든 문서를 조회하는 기능 추가 `/api/notes/user/{userId}` 7795692e78ed68033ca098e13b04db680355f0b6
### style
- Javadoc description 의 끝에 빈 줄을 추가 9d01f5bc7f102401b88b14c49b5ddcc29604c46c

## 설명
- https://github.com/CBNU-MoaNote-CapstonDesign/frontend/pull/37 해당 PR 에 적힌 이슈에 대한 대응입니다

## 관련 이슈
- #52
- #53