### PR TITLE
[Fix] text chat 에서 username 을 반환해야 하는 곳이 user 의 id 를 반환하던 오류 해결

### DIFF
--- a/src/main/java/moanote/backend/dto/UserChatMessageBroadcastDTO.java
+++ b/src/main/java/moanote/backend/dto/UserChatMessageBroadcastDTO.java
@@ -1,5 +1,7 @@
 package moanote.backend.dto;
 
+import java.util.UUID;
+
 /**
  * <pre>
  *   유저가 보낸 채팅 메시지를 가공하여 전파할 때 사용하는 DTO
@@ -14,7 +16,7 @@ package moanote.backend.dto;
  * @param messageContent 메시지 내용
  * @param chatId 채팅 객체 ID (UUIDv7)
  */
-public record UserChatMessageBroadcastDTO(String messageType, String senderId, String senderName,
-                                          String date, String messageContent, String chatId) {
+public record UserChatMessageBroadcastDTO(String messageType, UUID senderId, String senderName,
+                                          String date, String messageContent, UUID chatId) {
 
 }

--- a/src/main/java/moanote/backend/dto/UserChatSendDTO.java
+++ b/src/main/java/moanote/backend/dto/UserChatSendDTO.java
@@ -1,5 +1,7 @@
 package moanote.backend.dto;
 
+import java.util.UUID;
+
 /**
  * <pre>
  *   UserChatSendDTO
@@ -9,6 +11,6 @@ package moanote.backend.dto;
  * @param senderId 보낸 사람의 ID
  * @param messageContent 메시지 내용
  */
-public record UserChatSendDTO(String messageType, String senderId, String messageContent) {
+public record UserChatSendDTO(String messageType, UUID senderId, String messageContent) {
 
 }

--- a/src/main/java/moanote/backend/service/ChatbotService.java
+++ b/src/main/java/moanote/backend/service/ChatbotService.java
@@ -65,9 +65,9 @@ public class ChatbotService {
     String messageType = "bot";
     String date = LocalDateTime.now().atZone(ZoneId.systemDefault())
         .withZoneSameInstant(ZoneId.of("UTC")).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
-    String chatId = UuidCreator.getTimeOrderedEpoch().toString();
+    UUID chatId = UuidCreator.getTimeOrderedEpoch();
 
-    return new UserChatMessageBroadcastDTO(messageType, AGENT_UUID.toString(), AGENT_NAME, date,
+    return new UserChatMessageBroadcastDTO(messageType, AGENT_UUID, AGENT_NAME, date,
         content, chatId);
   }
 

--- a/src/main/java/moanote/backend/service/TextChatService.java
+++ b/src/main/java/moanote/backend/service/TextChatService.java
@@ -3,10 +3,13 @@ package moanote.backend.service;
 import com.github.f4b6a3.uuid.UuidCreator;
 import moanote.backend.dto.UserChatMessageBroadcastDTO;
 import moanote.backend.dto.UserChatSendDTO;
+import moanote.backend.repository.UserDataRepository;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.UUID;
 
 
 /**
@@ -16,6 +19,13 @@ import java.time.format.DateTimeFormatter;
  */
 @Service
 public class TextChatService {
+
+  private final UserDataRepository userDataRepository;
+
+  @Autowired
+  public TextChatService(UserDataRepository userDataRepository) {
+    this.userDataRepository = userDataRepository;
+  }
 
   /**
    * <pre>
@@ -43,10 +53,10 @@ public class TextChatService {
 
     // TODO@ Authority 기능 구현 후 이를 통한 user id 확인 및 username 불러오기
     UUID senderId = message.senderId();
-    String senderName = userDataRepository.findById(UUID.fromString(message.senderId())).orElseThrow().getUsername();
+    String senderName = userDataRepository.findById(message.senderId()).orElseThrow().getUsername();
     String date = LocalDateTime.now().atZone(ZoneId.systemDefault())
         .withZoneSameInstant(ZoneId.of("UTC")).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
-    String chatId = UuidCreator.getTimeOrderedEpoch().toString();
+    UUID chatId = UuidCreator.getTimeOrderedEpoch();
     return new UserChatMessageBroadcastDTO(message.messageType(), senderId, senderName, date, messageContent,
         chatId);
   }


### PR DESCRIPTION
## 수행한 작업
### fix
- 송신자 username 이 실제로는 id 가 들어가던 오류 수정 7499b27486fcd9768d75fd0256d77d154b405be6
### feat
- id 를 다루는 필드의 타입을 String 에서 UUID 로 변경 13c8d6d349c691ab86588c9ea383e45d3fb6731c