### PR TITLE
[Feature] 파일 접근 권한이 있는 유저 목록 반환 API / 파일 접근 권한을 다른 유저에게 부여할 수 있는 API 추가

### DIFF
--- a/src/main/java/moanote/backend/controller/FileController.java
+++ b/src/main/java/moanote/backend/controller/FileController.java
@@ -4,6 +4,7 @@ package moanote.backend.controller;
 import moanote.backend.dto.FileCreateDTO;
 import moanote.backend.dto.FileDTO;
 import moanote.backend.dto.FileEditDTO;
+import moanote.backend.dto.ShareFileDTO;
 import moanote.backend.service.FileService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -40,7 +41,7 @@ public class FileController {
   }
 
   @GetMapping("/metadata/{fileId}")
-  public ResponseEntity<FileDTO> fileMetadata(@PathVariable(required = false) UUID fileId, @RequestParam(name = "user", required = true) UUID userId) {
+  public ResponseEntity<FileDTO> fileMetadata(@PathVariable UUID fileId, @RequestParam(name = "user", required = true) UUID userId) {
 
     try {
       return ResponseEntity.ok().body(fileService.getFileById(fileId, userId));
@@ -50,6 +51,16 @@ public class FileController {
     } catch (IllegalArgumentException e) {
       System.out.println(e.getMessage());
       return ResponseEntity.status(403).body(null);
+    } catch (Exception e) {
+      System.out.println(e.getMessage());
+      return ResponseEntity.status(500).body(null);
+    }
+  }
+
+  @GetMapping("/api/files/all/{userId}")
+  public ResponseEntity<List<FileDTO>> allFileAccessible(@PathVariable UUID userId) {
+    try {
+      return ResponseEntity.ok().body(fileService.getFileDTOByUserId(userId));
     } catch (Exception e) {
       System.out.println(e.getMessage());
       return ResponseEntity.status(500).body(null);
@@ -107,6 +118,24 @@ public class FileController {
   public ResponseEntity<Void> deleteFile(@PathVariable UUID fileId, @RequestParam(name = "user") UUID userId) {
     try {
       fileService.deleteFile(fileId, userId);
+      return ResponseEntity.noContent().build();
+    } catch (NoSuchElementException e) {
+      System.out.println(e.getMessage());
+      return ResponseEntity.status(404).build();
+    } catch (IllegalArgumentException e) {
+      System.out.println(e.getMessage());
+      return ResponseEntity.status(403).build();
+    } catch (Exception e) {
+      System.out.println(e.getMessage());
+      return ResponseEntity.status(500).build();
+    }
+  }
+
+  @PostMapping("/share/{fileId}")
+  public ResponseEntity<Void> shareFile(@PathVariable UUID fileId,
+      @RequestParam(name = "user") UUID userId, @RequestBody ShareFileDTO shareFileDTO) {
+    try {
+      fileService.shareFile(fileId, userId, shareFileDTO);
       return ResponseEntity.noContent().build();
     } catch (NoSuchElementException e) {
       System.out.println(e.getMessage());

--- a/src/main/java/moanote/backend/controller/FileController.java
+++ b/src/main/java/moanote/backend/controller/FileController.java
@@ -1,6 +1,7 @@
 package moanote.backend.controller;
 
 
+import moanote.backend.dto.CollaboratorDTO;
 import moanote.backend.dto.FileCreateDTO;
 import moanote.backend.dto.FileDTO;
 import moanote.backend.dto.FileEditDTO;
@@ -137,6 +138,23 @@ public class FileController {
     try {
       fileService.shareFile(fileId, userId, shareFileDTO);
       return ResponseEntity.noContent().build();
+    } catch (NoSuchElementException e) {
+      System.out.println(e.getMessage());
+      return ResponseEntity.status(404).build();
+    } catch (IllegalArgumentException e) {
+      System.out.println(e.getMessage());
+      return ResponseEntity.status(403).build();
+    } catch (Exception e) {
+      System.out.println(e.getMessage());
+      return ResponseEntity.status(500).build();
+    }
+  }
+
+  @GetMapping("/collaborators/{fileId}")
+  public ResponseEntity<List<CollaboratorDTO>> getCollaborators(@PathVariable UUID fileId,
+      @RequestParam(name = "user") UUID userId) {
+    try {
+      return ResponseEntity.ok().body(fileService.getCollaborators(fileId, userId));
     } catch (NoSuchElementException e) {
       System.out.println(e.getMessage());
       return ResponseEntity.status(404).build();

--- a/src/main/java/moanote/backend/controller/FileController.java
+++ b/src/main/java/moanote/backend/controller/FileController.java
@@ -58,7 +58,7 @@ public class FileController {
     }
   }
 
-  @GetMapping("/api/files/all/{userId}")
+  @GetMapping("/all/{userId}")
   public ResponseEntity<List<FileDTO>> allFileAccessible(@PathVariable UUID userId) {
     try {
       return ResponseEntity.ok().body(fileService.getFileDTOByUserId(userId));

--- a/src/main/java/moanote/backend/dto/CollaboratorDTO.java
+++ b/src/main/java/moanote/backend/dto/CollaboratorDTO.java
@@ -1,0 +1,11 @@
+package moanote.backend.dto;
+
+import moanote.backend.entity.FileUserData;
+import moanote.backend.entity.FileUserData.Permission;
+
+public record CollaboratorDTO(UserDataDTO user, Permission permission) {
+
+  public CollaboratorDTO(FileUserData fud) {
+    this(new UserDataDTO(fud.getUser()), fud.getPermission());
+  }
+}

--- a/src/main/java/moanote/backend/dto/ShareFileDTO.java
+++ b/src/main/java/moanote/backend/dto/ShareFileDTO.java
@@ -1,0 +1,7 @@
+package moanote.backend.dto;
+
+import moanote.backend.entity.FileUserData.Permission;
+
+public record ShareFileDTO(String username, Permission permission) {
+
+}

--- a/src/main/java/moanote/backend/entity/FileUserData.java
+++ b/src/main/java/moanote/backend/entity/FileUserData.java
@@ -30,15 +30,17 @@ public class FileUserData {
    */
   @Getter
   public enum Permission {
-    READ("READ"),
-    WRITE("WRITE"),
-    DELETE("DELETE"),
-    OWNER("OWNER");
+    READ("READ", 0),
+    WRITE("WRITE", 1),
+    DELETE("DELETE", 2),
+    OWNER("OWNER", 3);
 
     private final String permission;
+    private final int value;
 
-    Permission(String permission) {
+    Permission(String permission, int value) {
       this.permission = permission;
+      this.value = value;
     }
   }
 

--- a/src/main/java/moanote/backend/repository/UserDataRepository.java
+++ b/src/main/java/moanote/backend/repository/UserDataRepository.java
@@ -3,6 +3,7 @@ package moanote.backend.repository;
 import com.github.f4b6a3.uuid.UuidCreator;
 import moanote.backend.entity.UserData;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface UserDataRepository extends JpaRepository<UserData, UUID> {
@@ -13,5 +14,5 @@ public interface UserDataRepository extends JpaRepository<UserData, UUID> {
     userData.setId(UuidCreator.getTimeOrderedEpoch());
     return save(userData);
   }
-  UserData findByUsername(String username);
+  Optional<UserData> findByUsername(String username);
 }

--- a/src/main/java/moanote/backend/security/CustomUserDetailsService.java
+++ b/src/main/java/moanote/backend/security/CustomUserDetailsService.java
@@ -18,7 +18,7 @@ public class CustomUserDetailsService implements UserDetailsService {
 
   @Override
   public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-    UserData user = userDataRepository.findByUsername(username);
+    UserData user = userDataRepository.findByUsername(username).orElseThrow();
 
     if (user == null) {
       throw new UsernameNotFoundException("계정을 찾을 수 없습니다.");

--- a/src/main/java/moanote/backend/service/ChatbotService.java
+++ b/src/main/java/moanote/backend/service/ChatbotService.java
@@ -47,7 +47,7 @@ public class ChatbotService {
     this.AGENT_NAME = AGENT_NAME;
     UUID uuid;
     try {
-      uuid = userDataRepository.findByUsername(AGENT_NAME).getId();
+      uuid = userDataRepository.findByUsername(AGENT_NAME).orElseThrow().getId();
     } catch (Exception e) {
       UserData agent = userService.createUser(AGENT_NAME, "1234");;
       uuid = agent.getId();

--- a/src/main/java/moanote/backend/service/UserService.java
+++ b/src/main/java/moanote/backend/service/UserService.java
@@ -36,7 +36,7 @@ public class UserService {
   }
 
   public UserData findByUsername(String username) {
-    return userDataRepository.findByUsername(username);
+    return userDataRepository.findByUsername(username).orElseThrow();
   }
 
   public Optional<UserData> findById(UUID id) {

--- a/src/test/java/moanote/backend/service/FileServiceTest.java
+++ b/src/test/java/moanote/backend/service/FileServiceTest.java
@@ -1,7 +1,6 @@
 package moanote.backend.service;
 
 import jakarta.persistence.EntityManager;
-import jakarta.transaction.Transactional;
 import moanote.backend.BackendApplication;
 import moanote.backend.entity.File;
 import moanote.backend.entity.File.FileType;
@@ -18,10 +17,7 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.util.Assert;
 
-import javax.swing.text.html.parser.Entity;
 import java.util.ArrayList;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 @AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2, replace = AutoConfigureTestDatabase.Replace.ANY)
 @TestPropertySource("classpath:application.properties")
@@ -37,14 +33,15 @@ class FileServiceTest {
   private FileRepository fileRepository;
 
   @Autowired
-  private UserService userDataService;
+  private UserService userService;
 
   @Autowired
   private EntityManager entityManager;
 
+
   @Test
   void removeFilesRecursively() {
-    UserData userData = userDataService.createUser("testuser", "testpassword");
+    UserData userData = userService.createUser("testuser", "testpassword");
     File rootDirectory = fileRepository.getRootDirectory(userData);
     File subDirectory;
     ArrayList<File> subFilesAtRoot = new ArrayList<>();


### PR DESCRIPTION
## 수행한 작업
### feat
- 파일 접근 권한을 다른 유저에게 부여할 수 있는 API 구현 be1299f4eb2ebaad77b2e911656624c95e810b87
- Permission 의 enum 에 정수 값 매핑 추가 aaf63e7778058e7c393915a90ef4cb0a3d99b540
- 파일 접근 권한이 있는 유저 목록 반환 API 추가 ec9d003b375b5e61bd55809f152938b952088b90
### test
- 파일 접근 권한을 다른 유저에게 부여할 수 있는 API 테스트 추가 702fe609fe54b10fc1848e9988c7383b73c26135
- 파일 접근 권한이 있는 유저 목록 반환 API 테스트 추가 033f4d7b50d07ca9b3094516aeeb2fa246d45ba9

## 설명
- File 을 찾는 findByUsername 쿼리가 Optional 을 반환하도록 하는 수정 포함
- 권한을 가진 모든 파일 불러오는 기능 포함

## 관련 이슈
- #68
- #67